### PR TITLE
Replace deprecated `plot_confusion_matrix()`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 setuptools
-sklearn
+sklearn>=1
 matplotlib

--- a/train.py
+++ b/train.py
@@ -22,5 +22,5 @@ with open("metrics.txt", "w") as outfile:
     outfile.write("Accuracy: " + str(acc) + "\n")
 
 # Plot it
-disp = ConfusionMatrixDisplay.from_estimator(clf, X_test, y_test, normalize=True, cmap=plt.cm.Blues)
+disp = ConfusionMatrixDisplay.from_estimator(clf, X_test, y_test, normalize="true", cmap=plt.cm.Blues)
 plt.savefig("confusion_matrix.png")

--- a/train.py
+++ b/train.py
@@ -22,5 +22,5 @@ with open("metrics.txt", "w") as outfile:
     outfile.write("Accuracy: " + str(acc) + "\n")
 
 # Plot it
-disp = ConfusionMatrixDisplay.from_estimator(clf, X_test, y_test, cmap=plt.cm.Blues)
+disp = ConfusionMatrixDisplay.from_estimator(clf, X_test, y_test, normalize=True, cmap=plt.cm.Blues)
 plt.savefig("confusion_matrix.png")

--- a/train.py
+++ b/train.py
@@ -1,5 +1,5 @@
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.metrics import plot_confusion_matrix
+from sklearn.metrics import ConfusionMatrixDisplay
 import matplotlib.pyplot as plt
 import json
 import os
@@ -22,5 +22,5 @@ with open("metrics.txt", "w") as outfile:
     outfile.write("Accuracy: " + str(acc) + "\n")
 
 # Plot it
-disp = plot_confusion_matrix(clf, X_test, y_test, normalize="true", cmap=plt.cm.Blues)
-plt.savefig("plot.png")
+disp = ConfusionMatrixDisplay.from_estimator(clf, X_test, y_test, cmap=plt.cm.Blues)
+plt.savefig("confusion_matrix.png")

--- a/train.py
+++ b/train.py
@@ -22,5 +22,7 @@ with open("metrics.txt", "w") as outfile:
     outfile.write("Accuracy: " + str(acc) + "\n")
 
 # Plot it
-disp = ConfusionMatrixDisplay.from_estimator(clf, X_test, y_test, normalize="true", cmap=plt.cm.Blues)
+disp = ConfusionMatrixDisplay.from_estimator(
+    clf, X_test, y_test, normalize="true", cmap=plt.cm.Blues
+)
 plt.savefig("confusion_matrix.png")


### PR DESCRIPTION
`DEPRECATED: Function plot_confusion_matrix is deprecated in 1.0 and will be removed in 1.2. Use one of the class methods: ConfusionMatrixDisplay.from_predictions or ConfusionMatrixDisplay.from_estimator.`

[https://scikit-learn.org/stable/modules/generated/sklearn.metrics.plot_confusion_matrix.html](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.plot_confusion_matrix.html)