### PR TITLE
Update requirement scikit learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 setuptools
-sklearn>=1
+scikit-learn>=1
 matplotlib


### PR DESCRIPTION
Hey!

I've recently heard about your framework and I am really excited to work with it. 
I stumpled upon a minor bug. Installing sklearn via `sklearn` failed for me. Changing `sklearn` to `scikit-learn` in requirements.txt fixes this issue.  

Cheers